### PR TITLE
display mock cards with gradient and glassmorphic CardItem UI

### DIFF
--- a/lib/components/card_item.dart
+++ b/lib/components/card_item.dart
@@ -1,0 +1,71 @@
+import 'dart:ui';
+import 'package:flutter/material.dart';
+import '../data/card_model.dart';
+
+class CardItem extends StatelessWidget {
+  final CardModel card;
+
+  const CardItem({Key? key, required this.card}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      height: 220,
+      margin: EdgeInsets.symmetric(horizontal: 20, vertical: 12),
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(24),
+        gradient: LinearGradient(
+          colors: [card.startColor, card.endColor],
+          begin: Alignment.topLeft,
+          end: Alignment.bottomRight,
+        ),
+        boxShadow: [
+          BoxShadow(
+            color: card.endColor.withOpacity(0.25),
+            offset: Offset(0, 10),
+            blurRadius: 18,
+          ),
+        ],
+      ),
+      child: ClipRRect(
+        borderRadius: BorderRadius.circular(24),
+        child: BackdropFilter(
+          filter: ImageFilter.blur(sigmaX: 6, sigmaY: 6),
+          child: Padding(
+            padding: const EdgeInsets.all(20),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  card.cardBrand,
+                  style: TextStyle(
+                    fontSize: 18,
+                    fontWeight: FontWeight.bold,
+                    color: Colors.white.withOpacity(0.9),
+                  ),
+                ),
+                Spacer(),
+                Text(
+                  card.cardNumber,
+                  style: TextStyle(
+                    fontSize: 22,
+                    letterSpacing: 2,
+                    color: Colors.white,
+                  ),
+                ),
+                SizedBox(height: 8),
+                Text(
+                  card.cardHolder,
+                  style: TextStyle(
+                    fontSize: 14,
+                    color: Colors.white70,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/data/card_model.dart
+++ b/lib/data/card_model.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/material.dart';
+
+class CardModel {
+  final String cardHolder;
+  final String cardNumber;
+  final String cardBrand;
+  final Color startColor;
+  final Color endColor;
+
+  CardModel({
+    required this.cardHolder,
+    required this.cardNumber,
+    required this.cardBrand,
+    required this.startColor,
+    required this.endColor,
+  });
+}

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -1,4 +1,6 @@
 import 'package:flutter/material.dart';
+import '../data/mock_cards.dart';
+import '../components/card_item.dart';
 
 class HomeScreen extends StatelessWidget {
   final VoidCallback toggleTheme;
@@ -22,11 +24,11 @@ class HomeScreen extends StatelessWidget {
           ),
         ],
       ),
-      body: Center(
-        child: Text(
-          'Welcome to CardHive!',
-          style: Theme.of(context).textTheme.headlineSmall,
-        ),
+      body: ListView.builder(
+        itemCount: mockCards.length,
+        itemBuilder: (context, index) {
+          return CardItem(card: mockCards[index]);
+        },
       ),
     );
   }


### PR DESCRIPTION
- Added CardModel and mockCards for sample card data
- Built CardItem widget with glass blur, gradient background, and layout
- Updated HomeScreen to render cards using ListView
- Connected card visuals to mock data
- Maintained compatibility with theme toggle